### PR TITLE
Map "ice tea" to "ice_tea" in console and back for action_server

### DIFF
--- a/src/nl_robot_console/console.py
+++ b/src/nl_robot_console/console.py
@@ -162,6 +162,7 @@ class REPL(cmd.Cmd):
 
             # TODO #5: Here, map the "ice_tea" back to the original "ice tea"
             params = recurse_replace_in_dict(params, self._underscore_mapping)
+            sem = str(params)  # To have the edits done on params also performed on the sem-antics.
 
             if debug:
                 print params


### PR DESCRIPTION
Mapping types with a space to to have _ and back again works but the entity_description has a _ in it when the action_server gets it somehow. WIP

Fixes https://github.com/tue-robotics/nl_robot_console/issues/5